### PR TITLE
Update ubootshell.py

### DIFF
--- a/lacie_uboot/ubootshell.py
+++ b/lacie_uboot/ubootshell.py
@@ -289,7 +289,7 @@ class Ubootshell(object):
         prompt = False
         len_command = 0
         # Don't try to wait for a prompt with bootm
-        if cmd == 'bootm':
+        if cmd in 'bootm':
             sock.close()
             return 42
 

--- a/lacie_uboot/ubootshell.py
+++ b/lacie_uboot/ubootshell.py
@@ -289,7 +289,7 @@ class Ubootshell(object):
         prompt = False
         len_command = 0
         # Don't try to wait for a prompt with bootm
-        if cmd in 'bootm':
+        if 'bootm' in cmd:
             sock.close()
             return 42
 


### PR DESCRIPTION
Allows lacie-uboot to return when issuing a boot command with new capsules format. bootm command now can be followed by an address, thus locking lacie-uboot in a loop with current if statement.
